### PR TITLE
Inserting keyframes with new keyframe poses set to currently tweened pose

### DIFF
--- a/TISFAT/UI/Timeline.cs
+++ b/TISFAT/UI/Timeline.cs
@@ -554,8 +554,10 @@ namespace TISFAT
 
 		public void InsertKeyframe()
 		{
-			Keyframe prev = null;
-			uint TargetTime = (uint)FrameNum;
+            Keyframe prev = null;
+            Keyframe next = null;
+
+            uint TargetTime = (uint)FrameNum;
 
 			for (int i = 0; i < SelectedFrameset.Keyframes.Count; i++)
 			{
@@ -563,15 +565,22 @@ namespace TISFAT
 					if (SelectedFrameset.Keyframes[i + 1] != null)
 						if (SelectedFrameset.Keyframes[i + 1].Time > TargetTime)
 						{
+                            // If there isn't a keyframe after this, something has gone horribly wrong, abort!
+                            if (i + 1 >= SelectedFrameset.Keyframes.Count)
+                                return;
+
 							prev = SelectedFrameset.Keyframes[i];
+                            next = SelectedFrameset.Keyframes[i + 1];
 							break;
 						}
 			}
 
-			if (prev == null)
+			if (prev == null || next == null)
 				return;
 
-			Program.Form_Main.Do(new KeyframeAddAction(SelectedLayer, SelectedFrameset, TargetTime, prev.State.Copy()));
+            // Add the new frame in an interpolated form between its neighbouring keyframes.
+            float interpolationAmount = (TargetTime - prev.Time) / (float)(next.Time - prev.Time);
+			Program.Form_Main.Do(new KeyframeAddAction(SelectedLayer, SelectedFrameset, TargetTime, prev.State.Copy(), next.State.Copy(), interpolationAmount));
 		}
 
 		public void RemoveKeyframe()

--- a/TISFAT/UI/Timeline.cs
+++ b/TISFAT/UI/Timeline.cs
@@ -554,10 +554,10 @@ namespace TISFAT
 
 		public void InsertKeyframe()
 		{
-            Keyframe prev = null;
-            Keyframe next = null;
+			Keyframe prev = null;
+			Keyframe next = null;
 
-            uint TargetTime = (uint)FrameNum;
+			uint TargetTime = (uint)FrameNum;
 
 			for (int i = 0; i < SelectedFrameset.Keyframes.Count; i++)
 			{
@@ -565,12 +565,12 @@ namespace TISFAT
 					if (SelectedFrameset.Keyframes[i + 1] != null)
 						if (SelectedFrameset.Keyframes[i + 1].Time > TargetTime)
 						{
-                            // If there isn't a keyframe after this, something has gone horribly wrong, abort!
-                            if (i + 1 >= SelectedFrameset.Keyframes.Count)
-                                return;
+							// If there isn't a keyframe after this, something has gone horribly wrong, abort!
+							if (i + 1 >= SelectedFrameset.Keyframes.Count)
+								return;
 
 							prev = SelectedFrameset.Keyframes[i];
-                            next = SelectedFrameset.Keyframes[i + 1];
+							next = SelectedFrameset.Keyframes[i + 1];
 							break;
 						}
 			}
@@ -579,7 +579,7 @@ namespace TISFAT
 				return;
 
             // Add the new frame in an interpolated form between its neighbouring keyframes.
-            float interpolationAmount = (TargetTime - prev.Time) / (float)(next.Time - prev.Time);
+			float interpolationAmount = (TargetTime - prev.Time) / (float)(next.Time - prev.Time);
 			Program.Form_Main.Do(new KeyframeAddAction(SelectedLayer, SelectedFrameset, TargetTime, prev.State.Copy(), next.State.Copy(), interpolationAmount));
 		}
 

--- a/TISFAT/src/Core/Keyframe.cs
+++ b/TISFAT/src/Core/Keyframe.cs
@@ -18,13 +18,13 @@ namespace TISFAT
 		Keyframe AddedFrame;
 		int PrevSelectedFrame;
 
-		public KeyframeAddAction(Layer l, Frameset f, uint targ, IEntityState state)
+		public KeyframeAddAction(Layer l, Frameset f, uint targ, IEntityState start, IEntityState end, float interpolation)
 		{
 			LayerIndex = Program.ActiveProject.Layers.IndexOf(l);
 			FramesetIndex = l.Framesets.IndexOf(f);
 
-			Time = targ;
-			State = state;
+            Time = targ;
+			State = start.Interpolate(end, interpolation);
 		}
 
 		public bool Do()

--- a/TISFAT/src/Core/Keyframe.cs
+++ b/TISFAT/src/Core/Keyframe.cs
@@ -23,7 +23,7 @@ namespace TISFAT
 			LayerIndex = Program.ActiveProject.Layers.IndexOf(l);
 			FramesetIndex = l.Framesets.IndexOf(f);
 
-            Time = targ;
+			Time = targ;
 			State = start.Interpolate(end, interpolation);
 		}
 

--- a/TISFAT/src/Entities/BitmapObject.State.cs
+++ b/TISFAT/src/Entities/BitmapObject.State.cs
@@ -28,12 +28,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
-            {
-                return BitmapObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
-            }
+			public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+			{
+				return BitmapObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+			}
 
-            public int HandleAtLocation(PointF location)
+			public int HandleAtLocation(PointF location)
 			{
 				float size = Math.Min(12, TexWidth / 2);
 

--- a/TISFAT/src/Entities/BitmapObject.State.cs
+++ b/TISFAT/src/Entities/BitmapObject.State.cs
@@ -28,7 +28,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-			public int HandleAtLocation(PointF location)
+            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+            {
+                return BitmapObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+            }
+
+            public int HandleAtLocation(PointF location)
 			{
 				float size = Math.Min(12, TexWidth / 2);
 

--- a/TISFAT/src/Entities/BitmapObject.cs
+++ b/TISFAT/src/Entities/BitmapObject.cs
@@ -15,9 +15,14 @@ namespace TISFAT.Entities
 
 		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
 		{
-			State current = _current as State;
-			State target = _target as State;
-			State state = new State();
+            return _Interpolate(t, _current, _target, mode);
+		}
+
+        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            State current = _current as State;
+            State target = _target as State;
+            State state = new State();
 
 			state.Bounds = Interpolation.Interpolate(t, current.Bounds, target.Bounds, mode);
 			state.Rotation = Interpolation.Interpolate(t, current.Rotation, target.Rotation, mode);

--- a/TISFAT/src/Entities/BitmapObject.cs
+++ b/TISFAT/src/Entities/BitmapObject.cs
@@ -15,14 +15,14 @@ namespace TISFAT.Entities
 
 		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
 		{
-            return _Interpolate(t, _current, _target, mode);
+			return _Interpolate(t, _current, _target, mode);
 		}
 
-        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            State current = _current as State;
-            State target = _target as State;
-            State state = new State();
+		private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			State current = _current as State;
+			State target = _target as State;
+			State state = new State();
 
 			state.Bounds = Interpolation.Interpolate(t, current.Bounds, target.Bounds, mode);
 			state.Rotation = Interpolation.Interpolate(t, current.Rotation, target.Rotation, mode);

--- a/TISFAT/src/Entities/CircleObject.State.cs
+++ b/TISFAT/src/Entities/CircleObject.State.cs
@@ -28,12 +28,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
-            {
-                return CircleObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
-            }
+			public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+			{
+				return CircleObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+			}
 
-            public void Move(PointF target, ManipulateParams mparams)
+			public void Move(PointF target, ManipulateParams mparams)
 			{
 				if (mparams.AbsoluteDrag)
 				{

--- a/TISFAT/src/Entities/CircleObject.State.cs
+++ b/TISFAT/src/Entities/CircleObject.State.cs
@@ -28,7 +28,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-			public void Move(PointF target, ManipulateParams mparams)
+            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+            {
+                return CircleObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+            }
+
+            public void Move(PointF target, ManipulateParams mparams)
 			{
 				if (mparams.AbsoluteDrag)
 				{

--- a/TISFAT/src/Entities/CircleObject.cs
+++ b/TISFAT/src/Entities/CircleObject.cs
@@ -13,12 +13,12 @@ namespace TISFAT.Entities
 	{
 		public CircleObject() { }
 
-        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            return _Interpolate(t, _current, _target, mode);
-        }
+		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			return _Interpolate(t, _current, _target, mode);
+		}
 
-        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
 		{
 			State current = _current as State;
 			State target = _target as State;

--- a/TISFAT/src/Entities/CircleObject.cs
+++ b/TISFAT/src/Entities/CircleObject.cs
@@ -13,7 +13,12 @@ namespace TISFAT.Entities
 	{
 		public CircleObject() { }
 
-		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            return _Interpolate(t, _current, _target, mode);
+        }
+
+        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
 		{
 			State current = _current as State;
 			State target = _target as State;

--- a/TISFAT/src/Entities/LineObject.State.cs
+++ b/TISFAT/src/Entities/LineObject.State.cs
@@ -31,12 +31,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
-            {
-                return LineObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
-            }
+			public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+			{
+				return LineObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+			}
 
-            public int HandleAtLocation(PointF location)
+			public int HandleAtLocation(PointF location)
 			{
 				if (MathUtil.IsPointInPoint(location, Handle1, 4))
 					return 0;

--- a/TISFAT/src/Entities/LineObject.State.cs
+++ b/TISFAT/src/Entities/LineObject.State.cs
@@ -31,7 +31,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-			public int HandleAtLocation(PointF location)
+            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+            {
+                return LineObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+            }
+
+            public int HandleAtLocation(PointF location)
 			{
 				if (MathUtil.IsPointInPoint(location, Handle1, 4))
 					return 0;

--- a/TISFAT/src/Entities/LineObject.cs
+++ b/TISFAT/src/Entities/LineObject.cs
@@ -13,12 +13,12 @@ namespace TISFAT.Entities
 	{
 		public LineObject() { }
 
-        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            return _Interpolate(t, _current, _target, mode);
-        }
+		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			return _Interpolate(t, _current, _target, mode);
+		}
 
-        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
 		{
 			State current = _current as State;
 			State target = _target as State;

--- a/TISFAT/src/Entities/LineObject.cs
+++ b/TISFAT/src/Entities/LineObject.cs
@@ -13,7 +13,12 @@ namespace TISFAT.Entities
 	{
 		public LineObject() { }
 
-		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            return _Interpolate(t, _current, _target, mode);
+        }
+
+        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
 		{
 			State current = _current as State;
 			State target = _target as State;

--- a/TISFAT/src/Entities/PointLight.State.cs
+++ b/TISFAT/src/Entities/PointLight.State.cs
@@ -28,12 +28,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
-            {
-                return PointLight._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
-            }
+			public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+			{
+				return PointLight._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+			}
 
-            public void Move(PointF target, ManipulateParams mparams)
+			public void Move(PointF target, ManipulateParams mparams)
 			{
 				if (mparams.AbsoluteDrag)
 				{

--- a/TISFAT/src/Entities/PointLight.State.cs
+++ b/TISFAT/src/Entities/PointLight.State.cs
@@ -28,7 +28,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-			public void Move(PointF target, ManipulateParams mparams)
+            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+            {
+                return PointLight._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+            }
+
+            public void Move(PointF target, ManipulateParams mparams)
 			{
 				if (mparams.AbsoluteDrag)
 				{

--- a/TISFAT/src/Entities/PointLight.cs
+++ b/TISFAT/src/Entities/PointLight.cs
@@ -9,9 +9,14 @@ namespace TISFAT.Entities
 	{
 		public PointLight() { }
 
-		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-		{
-			State current = _current as State;
+        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            return _Interpolate(t, _current, _target, mode);
+        }
+
+        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            State current = _current as State;
 			State target = _target as State;
 			State state = new State();
 

--- a/TISFAT/src/Entities/PointLight.cs
+++ b/TISFAT/src/Entities/PointLight.cs
@@ -9,14 +9,14 @@ namespace TISFAT.Entities
 	{
 		public PointLight() { }
 
-        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            return _Interpolate(t, _current, _target, mode);
-        }
+		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			return _Interpolate(t, _current, _target, mode);
+		}
 
-        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            State current = _current as State;
+		private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			State current = _current as State;
 			State target = _target as State;
 			State state = new State();
 

--- a/TISFAT/src/Entities/PolyObject.State.cs
+++ b/TISFAT/src/Entities/PolyObject.State.cs
@@ -30,7 +30,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-			public void Move(PointF target, ManipulateParams mparams)
+            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+            {
+                return PolyObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+            }
+
+            public void Move(PointF target, ManipulateParams mparams)
 			{
 				if(mparams.AbsoluteDrag)
 				{

--- a/TISFAT/src/Entities/PolyObject.State.cs
+++ b/TISFAT/src/Entities/PolyObject.State.cs
@@ -30,12 +30,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
-            {
-                return PolyObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
-            }
+			public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+			{
+				return PolyObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+			}
 
-            public void Move(PointF target, ManipulateParams mparams)
+			public void Move(PointF target, ManipulateParams mparams)
 			{
 				if(mparams.AbsoluteDrag)
 				{

--- a/TISFAT/src/Entities/PolyObject.cs
+++ b/TISFAT/src/Entities/PolyObject.cs
@@ -15,14 +15,14 @@ namespace TISFAT.Entities
 
 		public PolyObject() { }
 
-        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            return _Interpolate(t, _current, _target, mode);
-        }
+		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			return _Interpolate(t, _current, _target, mode);
+		}
 
-        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            State current = _current as State;
+		private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			State current = _current as State;
 			State target = _target as State;
 			State state = new State();
 

--- a/TISFAT/src/Entities/PolyObject.cs
+++ b/TISFAT/src/Entities/PolyObject.cs
@@ -15,9 +15,14 @@ namespace TISFAT.Entities
 
 		public PolyObject() { }
 
-		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-		{
-			State current = _current as State;
+        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            return _Interpolate(t, _current, _target, mode);
+        }
+
+        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            State current = _current as State;
 			State target = _target as State;
 			State state = new State();
 

--- a/TISFAT/src/Entities/RectObject.State.cs
+++ b/TISFAT/src/Entities/RectObject.State.cs
@@ -26,7 +26,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-			public int HandleAtLocation(PointF location)
+            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+            {
+                return RectObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+            }
+
+            public int HandleAtLocation(PointF location)
 			{
 				float size = 6; // Dis is handle size
 

--- a/TISFAT/src/Entities/RectObject.State.cs
+++ b/TISFAT/src/Entities/RectObject.State.cs
@@ -26,12 +26,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
-            {
-                return RectObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
-            }
+			public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+			{
+				return RectObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+			}
 
-            public int HandleAtLocation(PointF location)
+			public int HandleAtLocation(PointF location)
 			{
 				float size = 6; // Dis is handle size
 

--- a/TISFAT/src/Entities/RectObject.cs
+++ b/TISFAT/src/Entities/RectObject.cs
@@ -13,7 +13,12 @@ namespace TISFAT.Entities
 	{
 		public RectObject() { }
 
-		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            return _Interpolate(t, _current, _target, mode);
+        }
+
+        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
 		{
 			State current = _current as State;
 			State target = _target as State;

--- a/TISFAT/src/Entities/RectObject.cs
+++ b/TISFAT/src/Entities/RectObject.cs
@@ -13,12 +13,12 @@ namespace TISFAT.Entities
 	{
 		public RectObject() { }
 
-        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            return _Interpolate(t, _current, _target, mode);
-        }
+		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			return _Interpolate(t, _current, _target, mode);
+		}
 
-        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
 		{
 			State current = _current as State;
 			State target = _target as State;

--- a/TISFAT/src/Entities/StickFigure.State.cs
+++ b/TISFAT/src/Entities/StickFigure.State.cs
@@ -17,12 +17,12 @@ namespace TISFAT.Entities
 				return new State { Root = this.Root.Clone() };
 			}
 
-            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
-            {
-                return StickFigure._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
-            }
+			public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+			{
+				return StickFigure._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+			}
 
-            public void Write(BinaryWriter writer)
+			public void Write(BinaryWriter writer)
 			{
 				Root.Write(writer);
 			}

--- a/TISFAT/src/Entities/StickFigure.State.cs
+++ b/TISFAT/src/Entities/StickFigure.State.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using TISFAT.Util;
 
 namespace TISFAT.Entities
 {
@@ -16,7 +17,12 @@ namespace TISFAT.Entities
 				return new State { Root = this.Root.Clone() };
 			}
 
-			public void Write(BinaryWriter writer)
+            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+            {
+                return StickFigure._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+            }
+
+            public void Write(BinaryWriter writer)
 			{
 				Root.Write(writer);
 			}

--- a/TISFAT/src/Entities/StickFigure.cs
+++ b/TISFAT/src/Entities/StickFigure.cs
@@ -18,9 +18,14 @@ namespace TISFAT.Entities
 			return new StickFigure() { Root = Root.Clone() };
 		}
 
-		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-		{
-			State current = _current as State;
+        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            return _Interpolate(t, _current, _target, mode);
+        }
+
+        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            State current = _current as State;
 			State target = _target as State;
 			State state = new State();
 			state.Root = Joint.State.Interpolate(t, current.Root, target.Root, mode);

--- a/TISFAT/src/Entities/StickFigure.cs
+++ b/TISFAT/src/Entities/StickFigure.cs
@@ -18,14 +18,14 @@ namespace TISFAT.Entities
 			return new StickFigure() { Root = Root.Clone() };
 		}
 
-        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            return _Interpolate(t, _current, _target, mode);
-        }
+		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			return _Interpolate(t, _current, _target, mode);
+		}
 
-        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            State current = _current as State;
+		private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			State current = _current as State;
 			State target = _target as State;
 			State state = new State();
 			state.Root = Joint.State.Interpolate(t, current.Root, target.Root, mode);

--- a/TISFAT/src/Entities/TextObject.State.cs
+++ b/TISFAT/src/Entities/TextObject.State.cs
@@ -34,12 +34,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
-            {
-                return TextObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
-            }
+			public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+			{
+				return TextObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+			}
 
-            public int HandleAtLocation(PointF location)
+			public int HandleAtLocation(PointF location)
 			{
 				float size = 6; // Dis is handle size
 

--- a/TISFAT/src/Entities/TextObject.State.cs
+++ b/TISFAT/src/Entities/TextObject.State.cs
@@ -34,7 +34,12 @@ namespace TISFAT.Entities
 				return state;
 			}
 
-			public int HandleAtLocation(PointF location)
+            public IEntityState Interpolate(IEntityState target, float interpolationAmount)
+            {
+                return TextObject._Interpolate(interpolationAmount, this, target, EntityInterpolationMode.Linear);
+            }
+
+            public int HandleAtLocation(PointF location)
 			{
 				float size = 6; // Dis is handle size
 

--- a/TISFAT/src/Entities/TextObject.cs
+++ b/TISFAT/src/Entities/TextObject.cs
@@ -13,9 +13,14 @@ namespace TISFAT.Entities
 	{
 		public TextObject() { }
 
-		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-		{
-			State current = _current as State;
+        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            return _Interpolate(t, _current, _target, mode);
+        }
+
+        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+        {
+            State current = _current as State;
 			State target = _target as State;
 			State state = new State();
 

--- a/TISFAT/src/Entities/TextObject.cs
+++ b/TISFAT/src/Entities/TextObject.cs
@@ -13,14 +13,14 @@ namespace TISFAT.Entities
 	{
 		public TextObject() { }
 
-        public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            return _Interpolate(t, _current, _target, mode);
-        }
+		public IEntityState Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			return _Interpolate(t, _current, _target, mode);
+		}
 
-        private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
-        {
-            State current = _current as State;
+		private static IEntityState _Interpolate(float t, IEntityState _current, IEntityState _target, EntityInterpolationMode mode)
+		{
+			State current = _current as State;
 			State target = _target as State;
 			State state = new State();
 

--- a/TISFAT/src/Interfaces/IEntity.cs
+++ b/TISFAT/src/Interfaces/IEntity.cs
@@ -27,6 +27,7 @@ namespace TISFAT
 
 	public interface IEntityState : ISaveable
 	{
-		IEntityState Copy();
-	}
+        IEntityState Copy();
+        IEntityState Interpolate(IEntityState target, float interpolationAmount);
+    }
 }

--- a/TISFAT/src/Interfaces/IEntity.cs
+++ b/TISFAT/src/Interfaces/IEntity.cs
@@ -27,7 +27,7 @@ namespace TISFAT
 
 	public interface IEntityState : ISaveable
 	{
-        IEntityState Copy();
-        IEntityState Interpolate(IEntityState target, float interpolationAmount);
-    }
+		IEntityState Copy();
+		IEntityState Interpolate(IEntityState target, float interpolationAmount);
+	}
 }


### PR DESCRIPTION
This makes a change so that newly added keyframes interpolate the properties of the neighbouring keyframes so that the object/figure properties/pose don't automatically reset to the previous frame (this is great for adding an additional keyframe in the middle of a tween and having the figure retain pose for tweaking).

The option in the right-click menu to set the pose to the previous frame is still there if old-style functionality is required/desired.