### PR TITLE
Fix for T2 bitmap joint loading.

### DIFF
--- a/TISFAT/src/Util/FileFormat.Legacy.cs
+++ b/TISFAT/src/Util/FileFormat.Legacy.cs
@@ -487,6 +487,12 @@ namespace TISFAT.Util.Legacy
 				m_nBitmapCount = reader.ReadInt32();
 				for (int f = 0; f < m_nBitmapCount; f++)
 				{
+					string bitmapName = "";
+					int nameLength = reader.ReadInt32();
+					reader.ReadByte(); //the first byte of a pascal string is the length
+					if (nameLength > 1)
+						bitmapName = new string(reader.ReadChars(nameLength - 1));
+											
 					Bitmap bmp = FileFormat.LoadBitmap(reader);
 					m_olBitmaps.Add(bmp);
 				}


### PR DESCRIPTION
T2 StickJoints prefix every bitmap with a name, these need to be loaded,
or at least SEEK'd over.